### PR TITLE
fix : #693, update react and react-dom version to 18.3.1

### DIFF
--- a/packages/material-tailwind-react/package.json
+++ b/packages/material-tailwind-react/package.json
@@ -25,8 +25,8 @@
     "framer-motion": "6.5.1",
     "material-ripple-effects": "2.0.1",
     "prop-types": "15.8.1",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "tailwind-merge": "1.8.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
This issue because mismatch of react-dom versions.
@material-tailwind/react dependencies such as @floating-ui/react uses react and dom version 18.3.1.
but @material-tailwind/react use react and dom version 18.2.0 .
you can update this versions to 18.3.1 in package-lock.json.
and reinstall all packages with npm install.

├─┬ @material-tailwind/react@2.1.9
│ ├─┬ @floating-ui/react@0.19.0
│ │ ├─┬ @floating-ui/react-dom@1.3.0
│ │ │ └── react@18.3.1 deduped
│ │ └── react@18.3.1 deduped
│ ├─┬ framer-motion@6.5.1
│ │ └── react@18.3.1 deduped
│ ├─┬ react-dom@18.2.0
│ │ └── react@18.2.0 deduped
│ └── react@18.2.0
├─┬ react-dom@18.3.1
│ └── react@18.3.1 deduped
└── react@18.3.1